### PR TITLE
Fix zombie removal iteration bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,8 @@
                 bullet.x > 0 && bullet.x < canvas.width && bullet.y > 0 && bullet.y < canvas.height
             ));
 
-            zombies.forEach(zombie => {
+            for (let i = zombies.length - 1; i >= 0; i--) {
+                const zombie = zombies[i];
                 const dx = player.x - zombie.x;
                 const dy = player.y - zombie.y;
                 const dist = Math.sqrt(dx * dx + dy * dy);
@@ -240,16 +241,18 @@
                     gameOverMenu.style.display = 'block';
                 }
 
-                bullets.forEach((bullet, bulletIndex) => {
-                    const bulletDist = Math.sqrt((bullet.x - zombie.x)**2 + (bullet.y - zombie.y)**2);
+                for (let j = bullets.length - 1; j >= 0; j--) {
+                    const bullet = bullets[j];
+                    const bulletDist = Math.sqrt((bullet.x - zombie.x) ** 2 + (bullet.y - zombie.y) ** 2);
                     if (bulletDist < (bulletSize + zombie.size) / 2) {
-                        zombies.splice(zombies.indexOf(zombie), 1);
-                        bullets.splice(bulletIndex, 1);
+                        zombies.splice(i, 1);
+                        bullets.splice(j, 1);
                         score++;
                         updateScore();
+                        break;
                     }
-                });
-            });
+                }
+            }
 
             // Gradual spawn rate increase
             spawnRate = 0.005 + Math.min(gameTime / 120000, 0.015); // Increase to max 0.02 over 120 seconds


### PR DESCRIPTION
## Summary
- fix skipping zombies during collision checks by iterating arrays backwards

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000`

------
https://chatgpt.com/codex/tasks/task_e_684a519c0ee88323a174dec8c6842b49